### PR TITLE
Strip byte order mark when compiling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -96,6 +96,7 @@ const watch = function (path, fullErr) {
 function readFile(file, options = {}) {
     return new Promise(function (resolve, reject) {
         fs.readFile(file, {encoding: "utf8"}, function (err, data) {
+            data = data.replace(/^\uFEFF|^\u00BB\u00BF/,""); // remove bom
 
             data = data.split("\n");
             for (let item of data) {


### PR DESCRIPTION
Fixes #36

Should I add an example file that has a byte order mark as a unit test?